### PR TITLE
Merge charging station address and properties, see also #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ Feel free to adjust the command line arguments to your needs:
   * `export` create a data export for the specified countries in `csv` or `geo-json` format
 * `online` fetch data online from original data sources, if `false` use files cached on disk
 
+
+Before re-running merge w/o re-import, delete corresponding DB entries
+
+    delete from echarm_merged_station_source ;
+    delete from echarm_address a where a.is_merged=true;
+    delete from echarm_stations es where es.is_merged=true ;
+    update echarm_stations SET merge_status = null;
+
+
 ## Contributing
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Feel free to adjust the command line arguments to your needs:
 Before re-running merge w/o re-import, delete corresponding DB entries
 
     delete from echarm_merged_station_source ;
+    delete from echarm_charging a where a.is_merged=true;
     delete from echarm_address a where a.is_merged=true;
     delete from echarm_stations es where es.is_merged=true ;
     update echarm_stations SET merge_status = null;

--- a/charging_stations_pipelines/deduplication/merger.py
+++ b/charging_stations_pipelines/deduplication/merger.py
@@ -102,6 +102,7 @@ class StationMerger:
                         merged_station.address = address
                     if merged_station and charging and not merged_station.charging :
                         merged_station.charging = charging
+            return merged_station
 
 
         if isinstance(stations_to_merge, pd.Series):

--- a/charging_stations_pipelines/deduplication/merger.py
+++ b/charging_stations_pipelines/deduplication/merger.py
@@ -4,7 +4,7 @@ from typing import Tuple
 
 import geopandas as gpd
 import pandas as pd
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, make_transient
 from tqdm import tqdm
 
 from charging_stations_pipelines.deduplication import attribute_match_thresholds_strategy
@@ -66,7 +66,7 @@ class StationMerger:
         station.at["merged_attributes"] = True
         return
 
-    def _merge_duplicates(self, stations_to_merge) -> Station:
+    def _merge_duplicates(self, stations_to_merge, session) -> Station:
         """
         Input DataFrame has columns
                 station_id, source_id, data_source, point, operator, capacity, street, town, distance
@@ -89,17 +89,28 @@ class StationMerger:
                 logger.debug(f"attribute {column_name} not found ?!?!? {stations_to_merge}")
             return attribute
 
-        merged_station = Station()
-        merged_station.country_code = self.country_code
-        merged_station.is_merged = True
+        def get_station_with_address_and_charging_by_priority(session):
+            for source in [self.gov_source, 'OCM', 'OSM']:
+                station_id = stations_to_merge[stations_to_merge['data_source'] == source]['station_id_col']
+                if len(station_id) > 0:
+                    station_id = int(station_id.iloc[0])
+                    return self.get_station_with_address_and_charging(session, station_id)
+
 
         if isinstance(stations_to_merge, pd.Series):
+            station_id = int(stations_to_merge['station_id_col'])
+            merged_station = self.get_station_with_address_and_charging(session, station_id)
+
             merged_station.data_source = stations_to_merge['data_source']
             merged_station.point = stations_to_merge['point'].wkt
             merged_station.operator = stations_to_merge['operator']
+
             source = MergedStationSource(duplicate_source_id=stations_to_merge['source_id'])
             merged_station.source_stations.append(source)
         else:
+
+            merged_station = get_station_with_address_and_charging_by_priority(session)
+
             data_sources = stations_to_merge['data_source'].unique()
             data_sources.sort()
             merged_station.data_source = ",".join(data_sources)
@@ -109,11 +120,37 @@ class StationMerger:
             point = get_attribute_by_priority('point', priority_list=['OSM', 'OCM', self.gov_source])
             merged_station.point = point.wkt
             merged_station.operator = get_attribute_by_priority('operator')
+
             for source_id in stations_to_merge['source_id']:
                 source = MergedStationSource(duplicate_source_id=source_id)
                 merged_station.source_stations.append(source)
 
+        merged_station.country_code = self.country_code
+        merged_station.is_merged = True
+
         return merged_station
+
+    def get_station_with_address_and_charging(self, session, station_id):
+        # get station from DB and create new object
+        merged_station: Station = \
+            session.query(Station). \
+                filter(Station.id == station_id). \
+                first()
+        address = merged_station.address
+        charging = merged_station.charging
+        session.expunge(merged_station)  # expunge the object from session
+        make_transient(merged_station)
+        merged_station.id = None
+        merged_station.address = self.create_merged(address)
+        merged_station.charging = self.create_merged(charging)
+        return merged_station
+
+    def create_merged(self, address_or_charging):
+        make_transient(address_or_charging)
+        address_or_charging.id = None
+        address_or_charging.station_id = None
+        address_or_charging.is_merged = True
+        return address_or_charging
 
     def run(self):
         '''
@@ -176,7 +213,7 @@ class StationMerger:
                 # merge attributes of duplicates into one station
                 session.query(Station).filter(Station.id.in_(station_ids)) \
                     .update({Station.merge_status: "is_duplicate"}, synchronize_session='fetch')
-                merged_station: Station = self._merge_duplicates(stations_to_merge)
+                merged_station: Station = self._merge_duplicates(stations_to_merge, session)
                 session.add(merged_station)
                 write_session(session)
 
@@ -200,7 +237,7 @@ class StationMerger:
             WHERE ST_Dwithin(s.point, 
                               ST_PointFromText('{center_coordinates}', 4326)::geography, 
                               {radius_m}) 
-                              AND NOT is_merged
+                              AND NOT s.is_merged
                               AND (merge_status <> 'is_duplicate' OR merge_status is null) 
                               AND country_code='{country_code}';
         """

--- a/charging_stations_pipelines/models/address.py
+++ b/charging_stations_pipelines/models/address.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Date, ForeignKey, Integer, String
+from sqlalchemy import Column, Date, ForeignKey, Integer, String, Boolean
 from sqlalchemy.orm import relationship
 from sqlalchemy.types import Float
 
@@ -19,7 +19,8 @@ class Address(Base):
     country = Column(String)
     gmaps_latitude = Column(Float(precision=32))
     gmaps_longitude = Column(Float(precision=32))
+    is_merged = Column(Boolean, default=False)
     station = relationship("Station", back_populates="address")
 
     def __repr__(self):
-        return "<stations with id: {}>".format(self.id)
+        return f"<address: id {self.id}, station_id {self.station_id}, street: {self.street}, town: {self.town}>"

--- a/charging_stations_pipelines/models/charging.py
+++ b/charging_stations_pipelines/models/charging.py
@@ -27,6 +27,7 @@ class Charging(Base):
     dc_support = Column(Boolean)
     total_kw = Column(Float)
     max_kw = Column(Float)
+    is_merged = Column(Boolean, default=False)
     station = relationship("Station", back_populates="charging")
 
     def __repr__(self):


### PR DESCRIPTION
Merge charging station address and properties from original charging stations in order of priority: GOV, OCM, OSM
Just considers if address or charging data is available for one of the source and stops and takes it if it finds it, but doesn't searches for each attributes inside both categories in detail across all data sources.
For merged station write new entries for address and charging properties with flag is_merged=true, so merged data can be easily deleted again and reference (station_id) from address or charging back to station is unique