### PR TITLE
Fix psycopg2 dependency for M1/M2 Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,21 @@ pip install -r requirements.txt
 
 **Trouble Shooting:**
 
-If pip install is failing during psycopg2 install, 
-search for openssl lib path (`which openssl` may help) 
+If pip install is failing during psycopg2 install:
+
+A) Search for openssl lib path (`which openssl` may help) 
 and identify which one is needed for linking the compiler for psycopg2 correctly. 
 Then export it as the corresponding LDFLAGS environment variable before pip install, for instance:
 
      export LDFLAGS="-L/usr/local/Cellar/openssl@3/3.1.3/lib"
+
+B) Ubuntu Users:
+
+Make sure you have the following packages installed:
+
+- build-essential
+- libgdal-dev
+- libpq5
 
 
 #### Set environment variables

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ source venv/bin/activate
 pip install -r requirements.txt  
 ```
 
+**Trouble Shooting:**
+
+If pip install is failing during psycopg2 install, 
+search for openssl lib path (`which openssl` may help) 
+and identify which one is needed for linking the compiler for psycopg2 correctly. 
+Then export it as the corresponding LDFLAGS environment variable before pip install, for instance:
+
+     export LDFLAGS="-L/usr/local/Cellar/openssl@3/3.1.3/lib"
+
+
 #### Set environment variables
 The following configuration parameters need to be set when using eCharm:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ openpyxl==3.0.9
 packaging==21.3
 pandas==1.4.1
 protobuf==4.21.9
-psycopg2-binary==2.9.3
+psycopg2==2.9.3
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pyparsing==3.0.9


### PR DESCRIPTION
For running on M1/M2 (ARM) Macs, we need to include the psycopg2 dependency not as binary, but it needs to be compiled otherwise the installation of psycopg2 fails.
Added some instructions to the Readme for trouble shooting.