### PR TITLE
Bugfix/fix country code in osm mapping

### DIFF
--- a/charging_stations_pipelines/pipelines/de/bna_mapper.py
+++ b/charging_stations_pipelines/pipelines/de/bna_mapper.py
@@ -59,12 +59,12 @@ def map_address_bna(row, station_id) -> Address:
     if len(postcode) == 4:
         postcode = "0" + postcode
     if len(postcode) != 5:
-        logger.warning(
+        logger.debug(
             f"Failed to process postcode {postcode}! Will set postcode to None!"
         )
         postcode = None
     if len(town) < 2:
-        logger.warning(f"Failed to process town {town}! Will set town to None!")
+        logger.debug(f"Failed to process town {town}! Will set town to None!")
         town = None
     map_address = Address()
     map_address.street = (street,)

--- a/charging_stations_pipelines/pipelines/osm/osm_mapper.py
+++ b/charging_stations_pipelines/pipelines/osm/osm_mapper.py
@@ -36,17 +36,18 @@ ADDRESS_KEYS: Final[list[str]] = [
 ]
 
 
-def map_station_osm(entry: JSON) -> Station:
+def map_station_osm(entry: JSON, country_code: str) -> Station:
     """Maps an entry from OpenStreetMap to a Station object.
 
     :param entry: The entry from OpenStreetMap to be mapped.
+    :param country_code: The country code for which this mapping is executed.
     :return: The mapped Station object.
     """
     lat = check_coordinates(entry.get("lat"))
     lon = check_coordinates(entry.get("lon"))
 
     new_station = Station()
-    new_station.country_code = str_strip_whitespace(entry.get("country_code")) or None
+    new_station.country_code = country_code
     new_station.source_id = entry.get("id") or None
     new_station.operator = (
         str_strip_whitespace(entry.get("tags", {}).get("operator")) or None

--- a/test/pipelines/osm/test_osm_mapper.py
+++ b/test/pipelines/osm/test_osm_mapper.py
@@ -57,7 +57,7 @@ from charging_stations_pipelines.shared import float_cmp_eq
     ],
 )
 def test_station_mapping(test_data, expected):
-    s = osm_mapper.map_station_osm(test_data)
+    s = osm_mapper.map_station_osm(test_data, "FR")
     assert s.country_code == expected["country_code"]
     assert s.source_id == expected["source_id"]
     assert s.operator == expected["operator"]

--- a/test/pipelines/osm/test_osm_mapper.py
+++ b/test/pipelines/osm/test_osm_mapper.py
@@ -21,7 +21,6 @@ from charging_stations_pipelines.shared import float_cmp_eq
     [
         (
             {
-                "country_code": "FR",
                 "id": 2144376575,
                 "lat": 48.0449426,
                 "lon": -1.602638,


### PR DESCRIPTION
Attribute "country_code" is not available in OSM data, use the pipelines coutry code (as was before)