### PR TITLE
fix running pytest in github and locally with pytest 8.0.0

### DIFF
--- a/.github/workflows/check-datasources.yml
+++ b/.github/workflows/check-datasources.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: "[DE/BNA] Data retrieval check"
         run: |
-          pytest tests/integration/test_int_de_bna.py
+          python -m pytest tests/integration/test_int_de_bna.py
 
       - name: "[FR] Data retrieval check"
         run: |
-          pytest tests/integration/test_int_fr_france.py
+          python -m pytest tests/integration/test_int_fr_france.py

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -45,4 +45,4 @@ jobs:
       - name: Run tests
         run: |
           pip install -r test/requirements.txt
-          pytest -m "not check_datasource"
+          python -m pytest -m "not check_datasource"

--- a/README.md
+++ b/README.md
@@ -193,14 +193,14 @@ Before you run the tests you need to install test dependencies by
 pip install -r test/requirements.txt
 ```
 
-You can run all tests under `/test` by running the following command:
+You can run all tests by running the following command:
 
 ```bash
 # to run all tests, use:
-pytest
+python -m pytest
 
 # ... or the following to run only the unit tests, i.e. not the integration tests (which run a bit longer): 
-pytest -m 'not integration_test' -W ignore::DeprecationWarning
+python -m pytest -m 'not integration_test'
 ```
 
 #### Testdata import / Integration test for the merger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,16 +15,20 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-
-# Set logging for code under test
-addopts = "--verbose  --capture=no --log-cli-level=DEBUG --log-cli-format='%(asctime)s %(levelname)s %(message)s' --log-cli-date-format='%Y-%m-%d %H:%M:%S' -W ignore::DeprecationWarning"
-
+addopts = [
+    "--import-mode=importlib",
+    "--capture=no",
+    "--log-level=WARN",
+    "--log-cli-level=DEBUG",
+    "--log-cli-format='%(asctime)s %(levelname)s %(message)s'",
+    "--log-cli-date-format='%Y-%m-%d %H:%M:%S'",
+    "-W ignore::DeprecationWarning"
+]
 # Limit search for tests to following folders
 testpaths = [
     "test", # TODO: move content to tests/unit/ folder
     "tests",
 ]
-
 # Declare custom markers
 markers = [
     "integration_test: marks tests as integration tests (deselect with '-m \"not integration_test\"')",


### PR DESCRIPTION
pytest released [v8.0.0](https://github.com/pytest-dev/pytest/releases/tag/8.0.0) which introduced some breaking changes.
Running `python -m pytest` instead of just `pytest` works around the issue this introduced, but long term we should probably think about a better global structure, see [pytest docs](https://docs.pytest.org/en/stable/explanation/goodpractices.html#which-import-mode) and https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure%3E